### PR TITLE
add NGSS classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ Practice problems occur after worked examples within the flow of the section con
 
 ```html
 <section class="ost-reading-discard test-prep multiple-choice">
-  <title>Multiple Choice</title>
+  <title>Test Prep Multiple Choice</title>
   <exercise class="os-exercise">
     <problem>
       <para><a class="os-embed" href="..." /></para>

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 - `ost-*`: Only OST cares about
   - `ost-tag-*`
     - `ost-tag-lo-*`: ie `ost-tag-lo-k12phys-ch12-s01-lo04` use k12phys to distinguish from college physics
+    - `ost-tag-ngss-k12phys-*`: ie `ost-tag-ngss-k12phys-hs-ps2-1`
     - `ost-tag-blooms-*`: ie `ost-tag-blooms-1`
     - `ost-tag-teks-*`: ie `ost-tag-teks-112-39-c-4c`
     - `ost-tag-dok-*`: ie `ost-tag-dok-1`
@@ -33,6 +34,7 @@
   - `ost-assignable`: Only on `snap-lab`s. 
   - `ost-teks-def` : Place on the text of the TEKS in teacher-content that tells what that TEKS addresses
   - `ost-learning-objective-def` : Place on the learning objective text that defines the LO 
+  - `ost-ngss-def` : Place on the Next Generation Science Standards (NGSS) text that defines the NGSS. Only occurs on Performance Task. 
 - no prefix: visual styling only
 
 
@@ -257,6 +259,14 @@ Notes:
 
 ### Special classes within teacher content
 
+####Teacher Content with NGSS tag
+
+```html
+<note class="os-teacher">
+  <label>Teacher Edition</label>
+  <p><span class="ost-tag-ngss-k12phys-hs-ps2-1 ost-ngss-def">NGSS HS-PS2-1</span>: Students who demonstrate understanding can: Analyze data to support the claim that Newton’s second law of motion describes the mathematical relationship among the net force on a macroscopic object, its mass, and its acceleration.</p>
+</note>
+
 ####Teacher Misconception Alert
 
 ```html
@@ -355,7 +365,7 @@ Practice problems occur after worked examples within the flow of the section con
 **Note:** `chapter-review-performance` is discarded from Tutor's i-reading and can be assigned as a separate step (similar to Snap Labs). 
 
 ```html
-<section class="ost-reading-discard ost-assignable chapter-review performance">
+<section class="ost-reading-discard ost-assignable chapter-review performance ost-tag-ngss-k12phys-*">
   <title>Performance Task</title>
   <exercise class="os-exercise">
     <problem>


### PR DESCRIPTION
W&N will add NGSS (Next Generation Science Standards) tags to chapter-review-performance items. These standards are defined externally to Tutor, and teachers will see them in TS content. To make sure they can be treated similarly to LO's, I think we should add: 
- ost-tag-ngss-k12phys-\* for NGSS items and ost-ngss-def class on the corresponding TS(see changes to Conventions, Performance Task example, and Teacher Content with NGSS example)
